### PR TITLE
Fix auto disable when exiting insert mode.

### DIFF
--- a/plugin/capslock.vim
+++ b/plugin/capslock.vim
@@ -63,16 +63,12 @@ augroup END
 " }}}1
 " Maps {{{1
 
-noremap  <silent> <Plug>CapsLockToggle  :<C-U>call <SID>toggle('i',1)<CR>
-noremap  <silent> <Plug>CapsLockEnable  :<C-U>call <SID>enable('i',1)<CR>
-noremap  <silent> <Plug>CapsLockDisable :<C-U>call <SID>disable('i')<CR>
-inoremap <silent> <Plug>CapsLockToggle  <C-R>=<SID>toggle('i')<CR>
-inoremap <silent> <Plug>CapsLockEnable  <C-R>=<SID>enable('i')<CR>
-inoremap <silent> <Plug>CapsLockDisable <C-R>=<SID>disable('i')<CR>
-cnoremap <silent> <Plug>CapsLockToggle  <C-R>=<SID>toggle('c')<CR>
-cnoremap <silent> <Plug>CapsLockEnable  <C-R>=<SID>enable('c')<CR>
-cnoremap <silent> <Plug>CapsLockDisable <C-R>=<SID>disable('c')<CR>
-cnoremap <silent>  <SID>CapsLockDisable <C-R>=<SID>disable('c')<CR>
+noremap  <silent> <Plug>CapsLockToggle  :<C-U>call <SID>toggle(1)<CR>
+noremap  <silent> <Plug>CapsLockEnable  :<C-U>call <SID>enable(1)<CR>
+noremap  <silent> <Plug>CapsLockDisable :<C-U>call <SID>disable()<CR>
+inoremap <silent> <Plug>CapsLockToggle  <C-R>=<SID>toggle()<CR>
+inoremap <silent> <Plug>CapsLockEnable  <C-R>=<SID>enable()<CR>
+inoremap <silent> <Plug>CapsLockDisable <C-R>=<SID>disable()<CR>
 
 if !hasmapto("<Plug>CapsLockToggle")
   imap <C-G>c <Plug>CapsLockToggle


### PR DESCRIPTION
Hi

I noticed that the automatic disable when exiting insert mode didn't work in the latest version.
So I have attempted to fix that.

This was the leas intrusive way I could find.
Though I'm not sure what your plan for the `'i'` and `'c'` arguments are. So maybe it is a mistake to remove those.

Thank you for this great plugin btw.
