### PR TITLE
Using CmdlineLeave to disable automatically

### DIFF
--- a/plugin/capslock.vim
+++ b/plugin/capslock.vim
@@ -104,6 +104,9 @@ cnoremap <silent> <Plug>CapsLockDisable <C-R>=<SID>disable('c')<CR>
 if empty(mapcheck("<C-L>", "i"))
   imap <C-L> <Plug>CapsLockToggle
 endif
+if empty(mapcheck("<C-L>", "c"))
+  cmap <C-L> <Plug>CapsLockToggle
+endif
 imap <C-G>c <Plug>CapsLockToggle
 nmap gC <Plug>CapsLockToggle
 

--- a/plugin/capslock.vim
+++ b/plugin/capslock.vim
@@ -59,25 +59,27 @@ function! s:enabled(mode) abort
   if a:mode == 'i' && exists('##InsertCharPre')
     return get(b:, 'capslock', 0)
   else
-    return maparg('a',a:mode) == 'A'
+    return maparg('a',a:mode) ==# 'A'
   endif
 endfunction
 
-function! s:exitcallback() abort
-  if s:enabled('i') == 1
-    call s:disable('i')
+function! s:exitcallback(mode) abort
+  if s:enabled(a:mode)
+    call s:disable(a:mode)
   endif
 endfunction
 
 function! CapsLockStatusline(...) abort
-  return s:enabled('i') ? (a:0 == 1 ? a:1 : '[Caps]') : ''
+  return (s:enabled('i') || s:enabled('c')) ? (a:0 == 1 ? a:1 : '[Caps]') : ''
 endfunction
 
 augroup capslock
   autocmd!
   autocmd User Flags call Hoist('window', 'CapsLockStatusline')
 
-  autocmd InsertLeave * call s:exitcallback()
+  autocmd CmdlineLeave : call s:exitcallback('c')
+
+  autocmd InsertLeave * call s:exitcallback('i')
   if exists('##InsertCharPre')
     autocmd InsertCharPre *
           \ if s:enabled('i') |


### PR DESCRIPTION
My first pull request! haha. So, I manage to get capslock disable automatically when leaving cmdline. Vim does not refresh the statusline when entering an ex command ([discussed in this link](https://github.com/vim-airline/vim-airline/issues/1361)), then I put this in .vimrc to get statusline working: 
`autocmd CmdlineEnter * redraws`
`autocmd CmdlineChanged * redraws`
Cmap:
`cmap <c-l> <plug>CapsLockToggle`
And it's working! \o/
Feel free to correct me, I'm adventuring into vimscript and Github!
